### PR TITLE
Update 1.20.4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation(kotlin("stdlib-jdk8"))
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:1.6.4")
     implementation("org.jetbrains.kotlinx:kotlinx-cli-jvm:0.3.5")
-    implementation("com.github.steveice10:mcprotocollib:1.20-1-SNAPSHOT")
+    implementation("com.github.steveice10:mcprotocollib:1.20.4-2-SNAPSHOT")
     implementation("org.fusesource.jansi:jansi:2.4.0")
 }
 

--- a/src/main/kotlin/dev/cubxity/tools/stresscraft/data/StressCraftSession.kt
+++ b/src/main/kotlin/dev/cubxity/tools/stresscraft/data/StressCraftSession.kt
@@ -4,7 +4,7 @@ import com.github.steveice10.mc.protocol.MinecraftProtocol
 import com.github.steveice10.mc.protocol.data.game.ClientCommand
 import com.github.steveice10.mc.protocol.data.game.ResourcePackStatus
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.ClientboundLoginPacket
-import com.github.steveice10.mc.protocol.packet.ingame.clientbound.ClientboundResourcePackPacket
+import com.github.steveice10.mc.protocol.packet.common.clientbound.ClientboundResourcePackPushPacket
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.ClientboundRespawnPacket
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.entity.player.ClientboundPlayerPositionPacket
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.entity.player.ClientboundSetHealthPacket
@@ -12,7 +12,7 @@ import com.github.steveice10.mc.protocol.packet.ingame.clientbound.level.Clientb
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.level.ClientboundLevelChunkWithLightPacket
 import com.github.steveice10.mc.protocol.packet.ingame.clientbound.level.ClientboundSetTimePacket
 import com.github.steveice10.mc.protocol.packet.ingame.serverbound.ServerboundClientCommandPacket
-import com.github.steveice10.mc.protocol.packet.ingame.serverbound.ServerboundResourcePackPacket
+import com.github.steveice10.mc.protocol.packet.common.serverbound.ServerboundResourcePackPacket
 import com.github.steveice10.mc.protocol.packet.ingame.serverbound.level.ServerboundAcceptTeleportationPacket
 import com.github.steveice10.packetlib.Session
 import com.github.steveice10.packetlib.event.session.DisconnectedEvent
@@ -89,9 +89,9 @@ class StressCraftSession(private val app: StressCraft) : SessionAdapter() {
             is ClientboundSetTimePacket -> {
                 timer.onWorldTimeUpdate(packet.time)
             }
-            is ClientboundResourcePackPacket -> {
+            is ClientboundResourcePackPushPacket -> {
                 app.options.acceptResourcePacks
-                    ?.let(::ServerboundResourcePackPacket)
+                    ?.let { ServerboundResourcePackPacket(packet.id, it) }
                     ?.let(session::send)
             }
         }


### PR DESCRIPTION
Bumps mcprotocollib to `1.20.4-2-SNAPSHOT` and adjusts resource packs to use the new packets